### PR TITLE
Make the draw.io executable customisable

### DIFF
--- a/chatu-drawio.el
+++ b/chatu-drawio.el
@@ -31,6 +31,17 @@
 
 (require 'chatu-common)
 
+(defcustom chatu-drawio-executable-func #'chatu-drawio--find-executable
+  "The function to find the drawio executable."
+  :group 'chatu
+  :type 'function)
+
+(defun chatu-drawio--find-executable ()
+  "Find the drawio executable on PATH, or else return nil."
+  (condition-case nil
+      (file-truename (executable-find "draw.io"))
+    (error nil)))
+
 (defun chatu-drawio-script (keyword-plist)
   "Get conversion script.
 KEYWORD-PLIST contains parameters from the chatu line."
@@ -42,14 +53,14 @@ KEYWORD-PLIST contains parameters from the chatu line."
          (page (plist-get keyword-plist :page)))
     (if (plist-get keyword-plist :nopdf)
         (format "%s %s -x %s -p %s -o %s >/dev/null 2>&1"
-                (file-truename (executable-find "draw.io"))
+                (funcall chatu-drawio-executable-func)
                 (if (plist-get keyword-plist :crop) "--crop" "")
                 (shell-quote-argument input-path)
                 (or page "0")
                 (shell-quote-argument output-path))
       (format "%s %s -x %s -p %s -o %s >/dev/null 2>&1 && \
 %s %s %s >/dev/null 2>&1 && rm %s"
-              (file-truename (executable-find "draw.io"))
+              (funcall chatu-drawio-executable-func)
               (if (plist-get keyword-plist :crop) "--crop" "")
               (shell-quote-argument input-path)
               (or page "0")

--- a/chatu-drawio.el
+++ b/chatu-drawio.el
@@ -37,10 +37,11 @@
   :type 'function)
 
 (defun chatu-drawio--find-executable ()
-  "Find the drawio executable on PATH, or else return nil."
-  (condition-case nil
+  "Find the drawio executable on PATH, or else return an error."
+  (condition-case err
       (file-truename (executable-find "draw.io"))
-    (error nil)))
+    (wrong-type-argument
+     (message "Cannot find the draw.io executable on the PATH."))))
 
 (defun chatu-drawio-script (keyword-plist)
   "Get conversion script.


### PR DESCRIPTION
Hi there,

This PR allows the draw.io executable to be customized through a function. This allows users who are running non-standard package managers (such as homebrew on MacOS, or Nix/Guix users) to roll their own logic for finding draw.io.

In my case, on MacOS after running `brew install homebrew`, the draw.io executable ends up in `/Applications/draw.io.app/Contents/MacOS/draw.io`, which isn't on my PATH (nor do I want it to be).

Additionally, I added a `condition-case` to the original executable-find logic, so that if the executable isn't found, a nicer error is shown in ` *Messages*`.

Thanks!
JH