### PR TITLE
Fix freeze of Emacs by chatu-add, if chatu-new was evaluated at the end of a org file.

### DIFF
--- a/chatu.el
+++ b/chatu.el
@@ -327,9 +327,9 @@
    "\""
    (if (derived-mode-p 'markdown-mode)
        " -->"
-     "\n#+results:"))
+     "\n#+results:\n"))
   (when (derived-mode-p 'org-mode)
-    (forward-line -1)))
+    (forward-line -2)))
 
 ;;;###autoload
 (defun chatu-add ()


### PR DESCRIPTION
I have found, that if I try to C-c C-c (chatu-add) one new chatu line, after chatu-new at the end of the org file, chatu-skip-lines will go to the infinite loop as it could not get to the line without "#+". 
So as a solution to this problem, I modified chatu-new so it inserts one empty line after "#+result:".